### PR TITLE
Handle missing username from request

### DIFF
--- a/helper/Formatter.php
+++ b/helper/Formatter.php
@@ -20,7 +20,7 @@ class Formatter
             'delete' => 'removed',
         ];
         $action = $actionMap[$payload->eventType] ?? null;
-        $username = $context->username;
+        $username = $context->username ?: 'Anonymous';
         $page = $payload->id;
         $link = $this->buildUrl($page);
         $title = "{$username} {$action} page <{$link}|{$page}>";


### PR DESCRIPTION
If changes made without no user, the notification would have empty places.

<img width="422" alt="image" src="https://user-images.githubusercontent.com/199095/230165833-42c70d07-4c19-414f-bf35-27a04f969cda.png">

this would look as Anonymous from now on:

<img width="490" alt="image" src="https://user-images.githubusercontent.com/199095/230165970-e2b56107-1ea7-46a6-9172-e7c3bc266b19.png">
