### PR TITLE
Fix unsupported event types (f.e revert) to crash plugin

### DIFF
--- a/helper/Payload.php
+++ b/helper/Payload.php
@@ -48,7 +48,7 @@ class Payload
         return $this->data[$name];
     }
 
-    private static function isValidEvent(string $eventType, Config $config): bool
+    private static function isValidEvent(?string $eventType, Config $config): bool
     {
         if ($eventType === 'create' && $config->notify_create) {
             return true;


### PR DESCRIPTION
#### TypeError: Argument 1 passed to dokuwiki\plugin\slacknotifier\helper\Payload::isValidEvent() must be of the type string, null given, called in /usr/share/dokuwiki/lib/plugins/slacknotifier/helper/Payload.php on line 32

An unforeseen error has occured. This is most likely a bug somewhere. It might be a problem in the slacknotifier plugin.

More info has been written to the DokuWiki error log.