### PR TITLE
CI: Update version in wiki after release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,4 +51,17 @@ jobs:
           repository: splitbrain/dokuwiki-versionfix
           path: versionfix
 
+      - name: Setup versionfix tool
+        working-directory: ./versionfix
+        env:
+          CONFIG_HOME: ${{ github.workspace }}
+        run: |
+          composer install --no-dev
+          cat <<EOF > $CONFIG_HOME/.dwversionfix.conf
+          dokuwiki_user  ${{ secrets.DOKUWIKI_USER }}
+          dokuwiki_pass  ${{ secrets.DOKUWIKI_PASS }}
+          github_user    ""
+          github_key     ""
+          EOF
+
 # vim:ts=2:sw=2:et

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,4 +64,10 @@ jobs:
           github_key     ""
           EOF
 
+      - name: Run versionfix tool
+        working-directory: ./versionfix
+        env:
+          HOME: ${{ github.workspace }}
+        run: php versionfix.php ${{ env.BASE }}
+
 # vim:ts=2:sw=2:et

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Configure release version
+      - name: Setup name and version
         id: version
         run: |
           VERSION=$(awk '$1 == "date" {print $2}' $INFOTXT)
           echo "VERSION=$VERSION" >> $GITHUB_ENV
+          BASE=$(awk '$1 == "base" {print $2}' $INFOTXT)
+          echo "BASE=$BASE" >> $GITHUB_ENV
 
       - name: Create release
         id: create_release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,7 @@
 # Create release on change to plugin.info.txt version line
 # https://github.com/dokuwiki/dokuwiki/issues/3951
+#
+# Requires DOKUWIKI_USER and DOKUWIKI_PASS secrets be set in GitHub Actions
 
 name: Release
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ on:
 
 env:
   INFOTXT: plugin.info.txt
+  PHP_VERSION: "8.2"
 
 jobs:
   release:
@@ -38,5 +39,10 @@ jobs:
           release_name: Release ${{ env.VERSION }}
           draft: false
           prerelease: false
+
+      - name: Setup PHP ${{ env.PHP_VERSION }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ env.PHP_VERSION }}
 
 # vim:ts=2:sw=2:et

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,4 +45,10 @@ jobs:
         with:
           php-version: ${{ env.PHP_VERSION }}
 
+      - name: Checkout dokuwiki versionfix tool
+        uses: actions/checkout@v3
+        with:
+          repository: splitbrain/dokuwiki-versionfix
+          path: versionfix
+
 # vim:ts=2:sw=2:et


### PR DESCRIPTION
Refs:
- https://github.com/dokuwiki/dokuwiki/issues/3951

Example run:
```
Run php versionfix.php slacknotifier
Searching for credentials in /home/runner/work/dokuwiki-plugin-slacknotifier/dokuwiki-plugin-slacknotifier/.dwversionfix.conf
found 1 matching extensions
Checking plugin:slacknotifier --------------------------
dokuwiki.org version: 2023-04-16
github.com version:   2023-04-16
last real commit:     2023-04-16
versions match, no update needed.
```

- https://github.com/glensc/dokuwiki-plugin-slacknotifier/actions/runs/4714814449/jobs/8361379439