### PR TITLE
Refactor: Move isValidNamespace check to Config class

### DIFF
--- a/action.php
+++ b/action.php
@@ -119,19 +119,6 @@ class action_plugin_slacknotifier extends ActionPlugin
         $this->submitPayload($this->config->webhook, $formatted);
     }
 
-    private function isValidNamespace(?string $validNamespaces): bool
-    {
-        if (!$validNamespaces) {
-            return true;
-        }
-
-        global $INFO;
-        $validNamespaces = explode(',', $validNamespaces);
-        $thisNamespace = explode(':', $INFO['namespace']);
-
-        return in_array($thisNamespace[0], $validNamespaces, true);
-    }
-
     private function isValidEvent(?string $eventType): bool
     {
         if ($eventType === 'create' && $this->config->notify_create) {

--- a/action.php
+++ b/action.php
@@ -106,7 +106,7 @@ class action_plugin_slacknotifier extends ActionPlugin
 
     private function processEvent(PageSaveEvent $event): void
     {
-        if (!$this->isValidNamespace($this->config->namespaces)) {
+        if (!$this->config->isValidNamespace($event->getNamespace())) {
             return;
         }
 
@@ -116,7 +116,6 @@ class action_plugin_slacknotifier extends ActionPlugin
 
         $formatter = new Formatter($this->config);
         $formatted = $formatter->format($event, new Context());
-
         $this->submitPayload($this->config->webhook, $formatted);
     }
 

--- a/event/PageSaveEvent.php
+++ b/event/PageSaveEvent.php
@@ -29,6 +29,14 @@ class PageSaveEvent extends BaseEvent
         return self::EVENT_TYPE[$this->changeType] ?? null;
     }
 
+    /**
+     * Root namespace of the page.
+     */
+    public function getNamespace(): string
+    {
+        return explode(':', $this->id, 2)[0];
+    }
+
     public function isCreate(): bool
     {
         return $this->changeType === DOKU_CHANGE_TYPE_CREATE;

--- a/helper/Config.php
+++ b/helper/Config.php
@@ -29,4 +29,18 @@ class Config
     {
         return $this->plugin->getConf($name, null);
     }
+
+    /**
+     * Return true if $namespace is configured as valid namespace.
+     */
+    public function isValidNamespace(string $namespace): bool
+    {
+        if (!$this->namespaces) {
+            return true;
+        }
+
+        $namespaces = explode(',', $this->namespaces);
+
+        return in_array($namespace, $namespaces, true);
+    }
 }


### PR DESCRIPTION
Avoids using `$INFO` global to find namespace. Extract namespace (root only) from the event data.