### PR TITLE
Fix namespace detection for pages in root

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,7 @@ Download the latest release from [Tags] page and install the plugin using the
 1. Create an Incoming Webhook on slack: https://api.slack.com/messaging/webhooks#create_a_webhook
 
 2. Enter the webhook into the slacknotifier configuration section in DokuWiki's Configuration Settings
+
+## Discord
+
+This plugin will work for discord as well, if you append /slack to the discord webhook url; see https://birdie0.github.io/discord-webhooks-guide/other/slack_formatting.html 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Download the latest release from [Tags] page and install the plugin using the
 
 2. Enter the webhook into the slacknotifier configuration section in DokuWiki's Configuration Settings
 
+## Root Namespace
+
+To incldue the root namespace, simply put a : in the namespace field in the config.
+
 ## Discord
 
 This plugin will work for discord as well, if you append /slack to the discord webhook url; see https://birdie0.github.io/discord-webhooks-guide/other/slack_formatting.html 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,4 @@ Download the latest release from [Tags] page and install the plugin using the
 
 ## Root Namespace
 
-To include the root namespace, simply put a : in the namespace field in the config.
-
-## Discord
-
-This plugin will work for discord as well, if you append /slack to the discord webhook url; see https://birdie0.github.io/discord-webhooks-guide/other/slack_formatting.html 
+To include the root namespace, simply put a `:` in the namespace field in the config.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Download the latest release from [Tags] page and install the plugin using the
 
 ## Root Namespace
 
-To incldue the root namespace, simply put a : in the namespace field in the config.
+To include the root namespace, simply put a : in the namespace field in the config.
 
 ## Discord
 

--- a/event/PageSaveEvent.php
+++ b/event/PageSaveEvent.php
@@ -38,7 +38,7 @@ class PageSaveEvent extends BaseEvent
         $pos = strpos($this->id, ':');
         if($pos === false)
         {
-            return ('');
+            return '';
         }
 
         return explode(':', $this->id, 2)[0];

--- a/event/PageSaveEvent.php
+++ b/event/PageSaveEvent.php
@@ -31,14 +31,13 @@ class PageSaveEvent extends BaseEvent
 
     /**
      * Root namespace of the page.
-     * Handle case of page being in root namespace
      */
     public function getNamespace(): string
     {
+        // Handle special case of page being in root namespace
         $pos = strpos($this->id, ':');
-        if($pos === false)
-        {
-            return '';
+        if ($pos === false) {
+            return ':';
         }
 
         return explode(':', $this->id, 2)[0];

--- a/event/PageSaveEvent.php
+++ b/event/PageSaveEvent.php
@@ -31,9 +31,16 @@ class PageSaveEvent extends BaseEvent
 
     /**
      * Root namespace of the page.
+     * Handle case of page being in root namespace
      */
     public function getNamespace(): string
     {
+        $pos = strpos($this->id, ':');
+        if($pos === false)
+        {
+            return ('');
+        }
+
         return explode(':', $this->id, 2)[0];
     }
 

--- a/helper/Config.php
+++ b/helper/Config.php
@@ -40,7 +40,10 @@ class Config
         }
 
         $namespaces = explode(',', $this->namespaces);
-
+        // Handle root namespace
+        if ($namespace === '') {
+            return in_array(':', $namespaces, true);
+        }
         return in_array($namespace, $namespaces, true);
     }
 }

--- a/helper/Config.php
+++ b/helper/Config.php
@@ -40,10 +40,7 @@ class Config
         }
 
         $namespaces = explode(',', $this->namespaces);
-        // Handle root namespace
-        if ($namespace === '') {
-            return in_array(':', $namespaces, true);
-        }
+
         return in_array($namespace, $namespaces, true);
     }
 }


### PR DESCRIPTION
Add support for changed pages in the root namespace.

> 
> Currently the code works very well except when changes are made to pages in the root namespace. Say you have a page :test. The function isValidNamespace is receiving 'test' in the $namespace function argument, rather than ':' or an empty string.
> 
> isValidNamespace seems to be called from processEvent(PageSaveEvent $event) in action.php, so it looks like the namespace set in the $event argument is incorrect for pages in the root.

Fixes #25 

